### PR TITLE
Add ArcGIS Maps SDK 5.0 as a map provider (v3.1)

### DIFF
--- a/CHANGES.TXT
+++ b/CHANGES.TXT
@@ -4,7 +4,7 @@ v3.1
 [NEW] ArcGIS Maps SDK for JavaScript 5.0 as a new map provider, using the SDK's web components (<arcgis-map>, <arcgis-scene>, <arcgis-feature-layer>) loaded from the single https://js.arcgis.com/5.0/ CDN module entry with runtime $arcgis.import() loading
 [NEW] OpenStreetMap is the default ArcGIS basemap — no API key required out of the box; optional ArcGIS Location Platform key unlocks Esri basemaps and private portal content
 [NEW] Web map and 3D web scene support via portal item ID; feature layer overlay by service URL or item ID
-[NEW] Content tags: INSERT_ARCGIS_WEBMAP(item_id[,h,w]) and INSERT_ARCGIS_WEBSCENE(item_id[,h,w]) for standalone embeds
+[NEW] Content tag: INSERT_ARCGIS_MAP(item_id[,h,w]) for standalone embeds — item type (web map vs web scene) is auto-resolved against the configured portal's items API and cached per item for a day
 [NEW] Admin options on the Maps page: ArcGIS portal URL, API key, default basemap, web map / web scene / feature layer item IDs
 [NEW] arcgis-map.js (ES module) handles single-point (data-lat/data-lon) and multi-location (data-locations JSON) graphics via arcgisViewReadyChange
 [NEW] Unit tests for the ArcGIS provider (44 tests, 105 assertions in the suite)

--- a/CHANGES.TXT
+++ b/CHANGES.TXT
@@ -1,5 +1,17 @@
 GeoPress Changelog
 ====================
+v3.1
+[NEW] ArcGIS Maps SDK for JavaScript 5.0 as a new map provider, using the SDK's web components (<arcgis-map>, <arcgis-scene>, <arcgis-feature-layer>) loaded from the single https://js.arcgis.com/5.0/ CDN module entry with runtime $arcgis.import() loading
+[NEW] OpenStreetMap is the default ArcGIS basemap — no API key required out of the box; optional ArcGIS Location Platform key unlocks Esri basemaps and private portal content
+[NEW] Web map and 3D web scene support via portal item ID; feature layer overlay by service URL or item ID
+[NEW] Content tags: INSERT_ARCGIS_WEBMAP(item_id[,h,w]) and INSERT_ARCGIS_WEBSCENE(item_id[,h,w]) for standalone embeds
+[NEW] Admin options on the Maps page: ArcGIS portal URL, API key, default basemap, web map / web scene / feature layer item IDs
+[NEW] arcgis-map.js (ES module) handles single-point (data-lat/data-lon) and multi-location (data-locations JSON) graphics via arcgisViewReadyChange
+[NEW] Unit tests for the ArcGIS provider (44 tests, 105 assertions in the suite)
+[FIXED] PHPUnit suite was broken on 3.0 with Patchwork "DefinedTooEarly" errors — Patchwork is now required explicitly before the Composer autoloader and WP function stubs moved into tests/wp-stubs.php
+[FIXED] GeoPress::get_location() returned a DB query for negative IDs instead of null (truthy negative integers); now guards with $loc_id <= 0
+[FIXED] $wpdb mock in 5 test files now sets postmeta and posts properties so get_geo()-driven tests run
+
 v3.0
 [NEW] Modernized for WordPress 6.x and PHP 8.0+
 [NEW] Full Block (Gutenberg) editor support: Location box in the document sidebar plus [geopress_map], [geopress_post_map], and [geopress_page_map] shortcodes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,10 +280,9 @@ These files bootstrap WordPress (require `wp-load.php`) and output XML directly.
 
 | Tag | Output |
 |-----|--------|
-| `INSERT_ARCGIS_WEBMAP(item_id[,h,w])` | Standalone `<arcgis-map item-id="…">` |
-| `INSERT_ARCGIS_WEBSCENE(item_id[,h,w])` | Standalone `<arcgis-scene item-id="…">` (3D) |
+| `INSERT_ARCGIS_MAP(item_id[,h,w])` | Standalone embed — `geopress_arcgis_resolve_item_type()` hits the portal's `/sharing/rest/content/items/{id}?f=json` endpoint and dispatches to `<arcgis-map>` for `"Web Map"` or `<arcgis-scene>` for `"Web Scene"`. The lookup is cached in a transient for `DAY_IN_SECONDS` so it costs one request per item, ever. Unresolvable items render as a web map (the SDK surfaces a load error if incompatible). |
 
-Both are parsed in `GeoPress::embed_map_inpost()` next to the existing `INSERT_*` tags.
+Parsed in `GeoPress::embed_map_inpost()` next to the existing `INSERT_*` tags.
 
 ### Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,3 +247,45 @@ Development for AI-assisted changes happens on: `claude/add-claude-documentation
 | `wp-kml-link.php` | `application/vnd.google-earth.kml+xml` | KML NetworkLink |
 
 These files bootstrap WordPress (require `wp-load.php`) and output XML directly.
+
+---
+
+## ArcGIS Provider (added in v3.1)
+
+`arcgis` is a first-class map format alongside the Mapstraction providers. Unlike the others it bypasses Mapstraction entirely and uses the **ArcGIS Maps SDK for JavaScript 5.0** web components.
+
+### Loading model
+
+`includes/class-geopress.php::register_scripts()` registers a single SDK module script — `https://js.arcgis.com/5.0/` — served as `type="module"` via a `script_loader_tag` filter. That URL is a module bundle that registers all the web components (`<arcgis-map>`, `<arcgis-scene>`, `<arcgis-feature-layer>`, …) and exposes a global `$arcgis.import()` loader. The plugin's own `arcgis-map.js` (also a module) calls `$arcgis.import("@arcgis/core/Graphic.js")` at runtime — there are no deep per-module CDN imports.
+
+`enqueue_map_api_scripts()` short-circuits when the configured provider is `arcgis`: it enqueues only the SDK + `arcgis-map.js` (+ a tiny `wp_add_inline_script` block with the user's API key and portal URL as `window.geopressArcGISConfig`), and does **not** enqueue Mapstraction / `geopress.js`. The admin location-picker still uses Mapstraction/OpenLayers regardless of provider.
+
+### Rendering
+
+`includes/class-geopress-maps.php` branches on `arcgis` in `geopress_map()` and `geopress_post_map()` to emit a `<arcgis-map>` element with `data-lat`/`data-lon` (single-point) or `data-locations` JSON (multi-point) attributes. `arcgis-map.js` attaches an `arcgisViewReadyChange` listener and adds a `Graphic` for each point. Standalone embeds — `geopress_arcgis_webmap_embed()` / `geopress_arcgis_webscene_embed()` — emit `<arcgis-map item-id="…">` and `<arcgis-scene item-id="…">` respectively.
+
+### Options (wp_options)
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `_geopress_arcgis_portal_url` | `https://www.arcgis.com` | ArcGIS Online or Enterprise portal |
+| `_geopress_arcgis_api_key` | `""` | Optional Location Platform API key; only needed for Esri basemaps or private content |
+| `_geopress_arcgis_basemap` | `osm` | Default basemap. `osm` works with no key; `arcgis/…` styles require a key |
+| `_geopress_arcgis_webmap_item_id` | `""` | Portal item ID for a web map |
+| `_geopress_arcgis_webscene_item_id` | `""` | Portal item ID for a 3D web scene |
+| `_geopress_arcgis_feature_layer_url` | `""` | Feature layer service URL |
+| `_geopress_arcgis_feature_layer_item_id` | `""` | Feature layer portal item ID |
+
+### Content tags
+
+| Tag | Output |
+|-----|--------|
+| `INSERT_ARCGIS_WEBMAP(item_id[,h,w])` | Standalone `<arcgis-map item-id="…">` |
+| `INSERT_ARCGIS_WEBSCENE(item_id[,h,w])` | Standalone `<arcgis-scene item-id="…">` (3D) |
+
+Both are parsed in `GeoPress::embed_map_inpost()` next to the existing `INSERT_*` tags.
+
+### Files
+
+- `arcgis-map.js` — ES module: `$arcgis.import()` readiness guard + `arcgisViewReadyChange` graphic placement.
+- `tests/Unit/Maps/ArcGISTest.php` — unit tests for the provider helpers and enqueue-time config injection.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Project home: <https://georss.org/geopress/>
 | `INSERT_LOCATION` | Location name as an hCard microformat |
 | `GEOPRESS_LOCATION(Address)` | Set the post's location inline by address |
 | `GEOPRESS_LOCATION([lat,lon])` | Set the post's location inline by coordinates |
-| `INSERT_ARCGIS_WEBMAP(item_id,h,w)` | Embed an ArcGIS Online/Enterprise web map by portal item ID (height/width optional) |
-| `INSERT_ARCGIS_WEBSCENE(item_id,h,w)` | Embed an ArcGIS Online/Enterprise 3D web scene by portal item ID |
+| `INSERT_ARCGIS_MAP(item_id,h,w)` | Embed an ArcGIS Online/Enterprise web map or 3D web scene by portal item ID — type is resolved automatically against the configured portal (cached 24 h) |
 
 Machine tags in WordPress post tags also work: `geo:lat=60.15`, `geo:lon=24.94`.
 
@@ -139,7 +138,7 @@ The test suite uses [Brain Monkey](https://github.com/Brain-WP/BrainMonkey) to s
 
 See [CHANGES.TXT](CHANGES.TXT) for the full history.
 
-**3.1** adds the [ArcGIS Maps SDK for JavaScript 5.0](https://developers.arcgis.com/javascript/latest/) as a new map provider — web maps, 3D scenes, feature layers, and the new `INSERT_ARCGIS_WEBMAP` / `INSERT_ARCGIS_WEBSCENE` content tags. Uses the single 5.0 CDN module entry with `$arcgis.import()` runtime loading; defaults to OpenStreetMap so no API key is required out of the box. Also unbreaks the PHPUnit suite (Patchwork bootstrap order) and fixes a latent `get_location()` negative-ID bug.
+**3.1** adds the [ArcGIS Maps SDK for JavaScript 5.0](https://developers.arcgis.com/javascript/latest/) as a new map provider — web maps, 3D scenes, feature layers, and a unified `INSERT_ARCGIS_MAP(item_id)` content tag that auto-resolves to the right component (web map or web scene) via the portal items API. Uses the single 5.0 CDN module entry with `$arcgis.import()` runtime loading; defaults to OpenStreetMap so no API key is required out of the box. Also unbreaks the PHPUnit suite (Patchwork bootstrap order) and fixes a latent `get_location()` negative-ID bug.
 
 **3.0** modernized the plugin for WordPress 6.x / PHP 8.0+, refactored the single-file plugin into modular classes, added Block editor support and a test suite, switched geocoding to Nominatim, and removed the discontinued Yahoo Maps provider.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > Geotag posts and pages, embed interactive maps, output geo microformats, and publish GeoRSS, KML, and GPX feeds.
 
-![Version](https://img.shields.io/badge/version-3.0-blue)
+![Version](https://img.shields.io/badge/version-3.1-blue)
 ![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-21759b)
 ![PHP](https://img.shields.io/badge/PHP-8.0%2B-777bb4)
 ![License](https://img.shields.io/badge/license-GPL--2.0%2B-green)
 
 GeoPress is a WordPress plugin that adds geographic tagging to your posts and pages. Give a post a location — by place name, street address, or `[latitude, longitude]` — and GeoPress geocodes it, stores it, and lets you embed maps and publish geodata feeds.
 
-- 🗺️ **Interactive maps** via the [Mapstraction](https://github.com/mapstraction/mxn) library (OpenLayers, OpenStreetMap, Google, Microsoft)
+- 🗺️ **Interactive maps** via the [Mapstraction](https://github.com/mapstraction/mxn) library (OpenLayers, OpenStreetMap, Google, Microsoft) or the [ArcGIS Maps SDK for JavaScript 5.0](https://developers.arcgis.com/javascript/latest/) (web components — `<arcgis-map>`, `<arcgis-scene>`, web maps and 3D scenes by portal item ID, feature-layer overlays)
 - 📡 **GeoRSS** in your Atom / RSS 2.0 / RDF feeds (Simple, W3C, or GML)
 - 🌍 **KML and GPX** feeds for Google Earth and GPS tools
 - 🏷️ **Microformats** (geo, adr, hCard) for the semantic web
@@ -58,6 +58,8 @@ Project home: <https://georss.org/geopress/>
 | `INSERT_LOCATION` | Location name as an hCard microformat |
 | `GEOPRESS_LOCATION(Address)` | Set the post's location inline by address |
 | `GEOPRESS_LOCATION([lat,lon])` | Set the post's location inline by coordinates |
+| `INSERT_ARCGIS_WEBMAP(item_id,h,w)` | Embed an ArcGIS Online/Enterprise web map by portal item ID (height/width optional) |
+| `INSERT_ARCGIS_WEBSCENE(item_id,h,w)` | Embed an ArcGIS Online/Enterprise 3D web scene by portal item ID |
 
 Machine tags in WordPress post tags also work: `geo:lat=60.15`, `geo:lon=24.94`.
 
@@ -135,7 +137,11 @@ The test suite uses [Brain Monkey](https://github.com/Brain-WP/BrainMonkey) to s
 
 ## Changelog
 
-See [CHANGES.TXT](CHANGES.TXT) for the full history. The latest release, **3.0**, modernizes the plugin for WordPress 6.x / PHP 8.0+, refactors the single-file plugin into modular classes, adds Block editor support and a test suite, switches geocoding to Nominatim, and removes the discontinued Yahoo Maps provider.
+See [CHANGES.TXT](CHANGES.TXT) for the full history.
+
+**3.1** adds the [ArcGIS Maps SDK for JavaScript 5.0](https://developers.arcgis.com/javascript/latest/) as a new map provider — web maps, 3D scenes, feature layers, and the new `INSERT_ARCGIS_WEBMAP` / `INSERT_ARCGIS_WEBSCENE` content tags. Uses the single 5.0 CDN module entry with `$arcgis.import()` runtime loading; defaults to OpenStreetMap so no API key is required out of the box. Also unbreaks the PHPUnit suite (Patchwork bootstrap order) and fixes a latent `get_location()` negative-ID bug.
+
+**3.0** modernized the plugin for WordPress 6.x / PHP 8.0+, refactored the single-file plugin into modular classes, added Block editor support and a test suite, switched geocoding to Nominatim, and removed the discontinued Yahoo Maps provider.
 
 ## Credits
 

--- a/arcgis-map.js
+++ b/arcgis-map.js
@@ -1,0 +1,100 @@
+/**
+ * GeoPress ArcGIS Maps SDK v5 integration.
+ *
+ * Loaded as type="module". Reads config from window.geopressArcGISConfig
+ * (injected by PHP via wp_add_inline_script), sets esriConfig, then
+ * attaches arcgisViewReadyChange listeners to web component elements
+ * that carry data-lat/data-lon (single-point) or data-locations (multi-point)
+ * attributes.
+ *
+ * No AMD require() — SDK 5 is pure ES modules.
+ */
+
+import Graphic from "https://js.arcgis.com/5.x/@arcgis/core/Graphic.js";
+import esriConfig from "https://js.arcgis.com/5.x/@arcgis/core/config.js";
+
+// Apply PHP-injected config (api key, portal URL for enterprise).
+const cfg = window.geopressArcGISConfig || {};
+if ( cfg.apiKey )    { esriConfig.apiKey    = cfg.apiKey; }
+if ( cfg.portalUrl ) { esriConfig.portalUrl = cfg.portalUrl; }
+
+const MARKER_SYMBOL = {
+	type:    "simple-marker",
+	color:   [ 226, 119, 40 ],
+	size:    12,
+	outline: { color: "white", width: 1 },
+};
+
+/**
+ * Single-point maps.
+ *
+ * PHP sets data-lat, data-lon, and data-name on <arcgis-map> or <arcgis-scene>.
+ * arcgis-map.js adds a graphic marker at that point once the view is ready.
+ */
+document.querySelectorAll( "arcgis-map[data-lat], arcgis-scene[data-lat]" ).forEach( el => {
+	const lat  = parseFloat( el.dataset.lat );
+	const lon  = parseFloat( el.dataset.lon );
+	const name = el.dataset.name || "";
+
+	if ( isNaN( lat ) || isNaN( lon ) ) {
+		return;
+	}
+
+	el.addEventListener( "arcgisViewReadyChange", event => {
+		if ( ! event.detail.ready ) {
+			return;
+		}
+		event.target.view.graphics.add(
+			new Graphic( {
+				geometry:      { type: "point", longitude: lon, latitude: lat },
+				symbol:        MARKER_SYMBOL,
+				popupTemplate: name ? { title: name } : undefined,
+			} )
+		);
+	} );
+} );
+
+/**
+ * Multi-location maps.
+ *
+ * PHP serialises a JSON array into data-locations on <arcgis-map>:
+ *   [ { lat, lon, name, details }, … ]
+ *
+ * arcgis-map.js adds a graphic for each location and auto-fits the view.
+ */
+document.querySelectorAll( "arcgis-map[data-locations]" ).forEach( el => {
+	let locations;
+	try {
+		locations = JSON.parse( el.dataset.locations );
+	} catch ( e ) {
+		return;
+	}
+
+	if ( ! Array.isArray( locations ) || ! locations.length ) {
+		return;
+	}
+
+	el.addEventListener( "arcgisViewReadyChange", event => {
+		if ( ! event.detail.ready ) {
+			return;
+		}
+		const view = event.target.view;
+
+		locations.forEach( loc => {
+			view.graphics.add(
+				new Graphic( {
+					geometry:      { type: "point", longitude: loc.lon, latitude: loc.lat },
+					symbol:        MARKER_SYMBOL,
+					popupTemplate: {
+						title:   loc.name    || "",
+						content: loc.details || "",
+					},
+				} )
+			);
+		} );
+
+		if ( view.graphics.length ) {
+			view.goTo( view.graphics.toArray() ).catch( () => {} );
+		}
+	} );
+} );

--- a/arcgis-map.js
+++ b/arcgis-map.js
@@ -10,8 +10,23 @@
  * No AMD require() — SDK 5 is pure ES modules.
  */
 
-import Graphic from "https://js.arcgis.com/5.x/@arcgis/core/Graphic.js";
-import esriConfig from "https://js.arcgis.com/5.x/@arcgis/core/config.js";
+// SDK 5.0 CDN module loading. The single https://js.arcgis.com/5.0/ entry
+// (loaded as type="module" by register_scripts()) registers the web components
+// and exposes the global $arcgis.import() loader. We pull the core modules we
+// need at runtime rather than via deep per-module CDN import URLs.
+
+// Wait until the SDK bootstrap has exposed $arcgis.import().
+async function geopressArcGISReady() {
+	while ( typeof window.$arcgis === "undefined" || typeof window.$arcgis.import !== "function" ) {
+		await new Promise( resolve => setTimeout( resolve, 50 ) );
+	}
+}
+await geopressArcGISReady();
+
+const [ { default: Graphic }, { default: esriConfig } ] = await Promise.all( [
+	$arcgis.import( "@arcgis/core/Graphic.js" ),
+	$arcgis.import( "@arcgis/core/config.js" ),
+] );
 
 // Apply PHP-injected config (api key, portal URL for enterprise).
 const cfg = window.geopressArcGISConfig || {};

--- a/geopress.php
+++ b/geopress.php
@@ -3,7 +3,7 @@
  * Plugin Name: GeoPress
  * Plugin URI:  https://georss.org/geopress/
  * Description: GeoPress adds geographic tagging of your posts and blog. Enter an address or latitude/longitude, embed interactive maps, and export GeoRSS/KML/GPX feeds.
- * Version:     3.0
+ * Version:     3.1
  * Author:      Andrew Turner & Mikel Maron
  * Author URI:  https://highearthorbit.com
  * License:     GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-define( 'GEOPRESS_VERSION',              '3.0' );
+define( 'GEOPRESS_VERSION',              '3.1' );
 define( 'GEOPRESS_DIR',                  plugin_dir_path( __FILE__ ) );
 define( 'GEOPRESS_URL',                  plugin_dir_url( __FILE__ ) );
 define( 'GEOPRESS_BASENAME',             plugin_basename( __FILE__ ) );

--- a/includes/class-geopress-admin.php
+++ b/includes/class-geopress-admin.php
@@ -365,6 +365,15 @@ class GeoPress_Admin {
 			update_option( '_geopress_controls_scale',     isset( $_POST['map_controls_scale'] ) );
 			update_option( '_geopress_default_zoom_level', (int) ( $_POST['default_zoom_level'] ?? 11 ) );
 
+			// ArcGIS Maps SDK v5 settings.
+			update_option( '_geopress_arcgis_portal_url',           esc_url_raw( wp_unslash( $_POST['arcgis_portal_url'] ?? 'https://www.arcgis.com' ) ) );
+			update_option( '_geopress_arcgis_api_key',              sanitize_text_field( wp_unslash( $_POST['arcgis_api_key'] ?? '' ) ) );
+			update_option( '_geopress_arcgis_basemap',              sanitize_text_field( wp_unslash( $_POST['arcgis_basemap'] ?? 'arcgis/navigation' ) ) );
+			update_option( '_geopress_arcgis_webmap_item_id',       sanitize_text_field( wp_unslash( $_POST['arcgis_webmap_item_id'] ?? '' ) ) );
+			update_option( '_geopress_arcgis_webscene_item_id',     sanitize_text_field( wp_unslash( $_POST['arcgis_webscene_item_id'] ?? '' ) ) );
+			update_option( '_geopress_arcgis_feature_layer_url',    esc_url_raw( wp_unslash( $_POST['arcgis_feature_layer_url'] ?? '' ) ) );
+			update_option( '_geopress_arcgis_feature_layer_item_id', sanitize_text_field( wp_unslash( $_POST['arcgis_feature_layer_item_id'] ?? '' ) ) );
+
 			echo '<div class="updated"><p><strong>' . esc_html__( 'Map layout updated.', 'geopress' ) . '</strong></p></div>';
 		}
 
@@ -449,6 +458,7 @@ class GeoPress_Admin {
 							'microsoft'     => 'Microsoft',
 							'openstreetmap' => 'OpenStreetMap',
 							'openlayers'    => 'OpenLayers',
+							'arcgis'        => 'ArcGIS',
 						);
 						foreach ( $formats as $val => $label ) {
 							printf(
@@ -516,6 +526,93 @@ class GeoPress_Admin {
 			</tr>
 		</table>
 		</fieldset>
+
+		<?php
+		$arcgis_portal_url          = get_option( '_geopress_arcgis_portal_url', 'https://www.arcgis.com' );
+		$arcgis_api_key             = get_option( '_geopress_arcgis_api_key', '' );
+		$arcgis_basemap             = get_option( '_geopress_arcgis_basemap', 'arcgis/navigation' );
+		$arcgis_webmap_item_id      = get_option( '_geopress_arcgis_webmap_item_id', '' );
+		$arcgis_webscene_item_id    = get_option( '_geopress_arcgis_webscene_item_id', '' );
+		$arcgis_fl_url              = get_option( '_geopress_arcgis_feature_layer_url', '' );
+		$arcgis_fl_item_id          = get_option( '_geopress_arcgis_feature_layer_item_id', '' );
+		?>
+		<h3><?php esc_html_e( 'ArcGIS Settings', 'geopress' ); ?></h3>
+		<p><em><?php esc_html_e( 'These settings apply when Map Format is set to ArcGIS. They allow loading web maps, web scenes, and feature layers from ArcGIS Online or an ArcGIS Enterprise portal.', 'geopress' ); ?></em></p>
+		<fieldset class="options">
+		<table width="100%" cellspacing="2" cellpadding="5" class="editform">
+			<tr valign="top">
+				<th width="33%" scope="row"><label for="arcgis_portal_url"><?php esc_html_e( 'Portal URL', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="url" name="arcgis_portal_url" id="arcgis_portal_url" value="<?php echo esc_attr( $arcgis_portal_url ); ?>" style="width:50%;" />
+					<br /><em><?php esc_html_e( 'ArcGIS Online or Enterprise portal URL. Default: https://www.arcgis.com', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_api_key"><?php esc_html_e( 'API Key', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="text" name="arcgis_api_key" id="arcgis_api_key" value="<?php echo esc_attr( $arcgis_api_key ); ?>" style="width:50%;" />
+					<br /><em><?php esc_html_e( 'ArcGIS Platform API key. Required for accessing private content or using ArcGIS basemap styles.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_basemap"><?php esc_html_e( 'Default Basemap', 'geopress' ); ?>:</label></th>
+				<td>
+					<select name="arcgis_basemap" id="arcgis_basemap">
+						<?php
+						$basemaps = array(
+							'arcgis/navigation'  => __( 'Navigation (streets)', 'geopress' ),
+							'arcgis/streets'     => __( 'Streets', 'geopress' ),
+							'arcgis/imagery'     => __( 'Imagery (satellite)', 'geopress' ),
+							'arcgis/terrain'     => __( 'Terrain', 'geopress' ),
+							'arcgis/oceans'      => __( 'Oceans', 'geopress' ),
+							'arcgis/community'   => __( 'Community', 'geopress' ),
+							'arcgis/light-gray'  => __( 'Light Gray', 'geopress' ),
+							'arcgis/dark-gray'   => __( 'Dark Gray', 'geopress' ),
+						);
+						foreach ( $basemaps as $val => $label ) {
+							printf(
+								'<option value="%s"%s>%s</option>',
+								esc_attr( $val ),
+								selected( $arcgis_basemap, $val, false ),
+								esc_html( $label )
+							);
+						}
+						?>
+					</select>
+					<br /><em><?php esc_html_e( 'Used when no Web Map Item ID is specified.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_webmap_item_id"><?php esc_html_e( 'Web Map Item ID', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="text" name="arcgis_webmap_item_id" id="arcgis_webmap_item_id" value="<?php echo esc_attr( $arcgis_webmap_item_id ); ?>" style="width:40%;" />
+					<br /><em><?php esc_html_e( 'Portal item ID of a Web Map to use as the default map base. Overrides the basemap setting above. Leave blank to use the default basemap.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_webscene_item_id"><?php esc_html_e( 'Web Scene Item ID', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="text" name="arcgis_webscene_item_id" id="arcgis_webscene_item_id" value="<?php echo esc_attr( $arcgis_webscene_item_id ); ?>" style="width:40%;" />
+					<br /><em><?php esc_html_e( 'Portal item ID of a 3D Web Scene. When set, INSERT_MAP will render a 3D SceneView instead of a 2D MapView.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_feature_layer_url"><?php esc_html_e( 'Feature Layer URL', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="url" name="arcgis_feature_layer_url" id="arcgis_feature_layer_url" value="<?php echo esc_attr( $arcgis_fl_url ); ?>" style="width:60%;" />
+					<br /><em><?php esc_html_e( 'URL of a Feature Layer service to overlay on all ArcGIS maps. Takes precedence over Feature Layer Item ID if both are set.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arcgis_feature_layer_item_id"><?php esc_html_e( 'Feature Layer Item ID', 'geopress' ); ?>:</label></th>
+				<td>
+					<input type="text" name="arcgis_feature_layer_item_id" id="arcgis_feature_layer_item_id" value="<?php echo esc_attr( $arcgis_fl_item_id ); ?>" style="width:40%;" />
+					<br /><em><?php esc_html_e( 'Portal item ID of a Feature Layer to overlay on all ArcGIS maps. Used only when Feature Layer URL is empty.', 'geopress' ); ?></em>
+				</td>
+			</tr>
+		</table>
+		</fieldset>
+
 		<div class="submit">
 			<input type="submit" name="Options" value="<?php echo esc_attr__( 'Save Map Layout', 'geopress' ); ?> &raquo;" />
 		</div>

--- a/includes/class-geopress-admin.php
+++ b/includes/class-geopress-admin.php
@@ -368,7 +368,7 @@ class GeoPress_Admin {
 			// ArcGIS Maps SDK v5 settings.
 			update_option( '_geopress_arcgis_portal_url',           esc_url_raw( wp_unslash( $_POST['arcgis_portal_url'] ?? 'https://www.arcgis.com' ) ) );
 			update_option( '_geopress_arcgis_api_key',              sanitize_text_field( wp_unslash( $_POST['arcgis_api_key'] ?? '' ) ) );
-			update_option( '_geopress_arcgis_basemap',              sanitize_text_field( wp_unslash( $_POST['arcgis_basemap'] ?? 'arcgis/navigation' ) ) );
+			update_option( '_geopress_arcgis_basemap',              sanitize_text_field( wp_unslash( $_POST['arcgis_basemap'] ?? 'osm' ) ) );
 			update_option( '_geopress_arcgis_webmap_item_id',       sanitize_text_field( wp_unslash( $_POST['arcgis_webmap_item_id'] ?? '' ) ) );
 			update_option( '_geopress_arcgis_webscene_item_id',     sanitize_text_field( wp_unslash( $_POST['arcgis_webscene_item_id'] ?? '' ) ) );
 			update_option( '_geopress_arcgis_feature_layer_url',    esc_url_raw( wp_unslash( $_POST['arcgis_feature_layer_url'] ?? '' ) ) );
@@ -530,7 +530,7 @@ class GeoPress_Admin {
 		<?php
 		$arcgis_portal_url          = get_option( '_geopress_arcgis_portal_url', 'https://www.arcgis.com' );
 		$arcgis_api_key             = get_option( '_geopress_arcgis_api_key', '' );
-		$arcgis_basemap             = get_option( '_geopress_arcgis_basemap', 'arcgis/navigation' );
+		$arcgis_basemap             = get_option( '_geopress_arcgis_basemap', 'osm' );
 		$arcgis_webmap_item_id      = get_option( '_geopress_arcgis_webmap_item_id', '' );
 		$arcgis_webscene_item_id    = get_option( '_geopress_arcgis_webscene_item_id', '' );
 		$arcgis_fl_url              = get_option( '_geopress_arcgis_feature_layer_url', '' );
@@ -560,6 +560,7 @@ class GeoPress_Admin {
 					<select name="arcgis_basemap" id="arcgis_basemap">
 						<?php
 						$basemaps = array(
+							'osm'                => __( 'OpenStreetMap (no API key)', 'geopress' ),
 							'arcgis/navigation'  => __( 'Navigation (streets)', 'geopress' ),
 							'arcgis/streets'     => __( 'Streets', 'geopress' ),
 							'arcgis/imagery'     => __( 'Imagery (satellite)', 'geopress' ),
@@ -579,7 +580,7 @@ class GeoPress_Admin {
 						}
 						?>
 					</select>
-					<br /><em><?php esc_html_e( 'Used when no Web Map Item ID is specified.', 'geopress' ); ?></em>
+					<br /><em><?php esc_html_e( 'Used when no Web Map Item ID is specified. OpenStreetMap needs no API key; ArcGIS basemaps require one.', 'geopress' ); ?></em>
 				</td>
 			</tr>
 			<tr valign="top">

--- a/includes/class-geopress-maps.php
+++ b/includes/class-geopress-maps.php
@@ -118,7 +118,7 @@ function geopress_arcgis_options() {
 	return array(
 		'portal_url'             => get_option( '_geopress_arcgis_portal_url', 'https://www.arcgis.com' ),
 		'api_key'                => get_option( '_geopress_arcgis_api_key', '' ),
-		'basemap'                => get_option( '_geopress_arcgis_basemap', 'arcgis/navigation' ),
+		'basemap'                => get_option( '_geopress_arcgis_basemap', 'osm' ),
 		'webmap_item_id'         => get_option( '_geopress_arcgis_webmap_item_id', '' ),
 		'webscene_item_id'       => get_option( '_geopress_arcgis_webscene_item_id', '' ),
 		'feature_layer_url'      => get_option( '_geopress_arcgis_feature_layer_url', '' ),

--- a/includes/class-geopress-maps.php
+++ b/includes/class-geopress-maps.php
@@ -207,6 +207,75 @@ function geopress_arcgis_webscene_embed( $item_id, $height = 0, $width = 0 ) {
 		. '</arcgis-scene><!-- end GeoPress ArcGIS WebScene -->' . "\n";
 }
 
+/**
+ * Resolves an ArcGIS portal item ID to its content type by querying the
+ * configured portal's items REST endpoint. Results are cached in a transient
+ * for a day so the lookup happens at most once per item per WordPress.
+ *
+ * @param string $item_id Portal item ID.
+ * @return string 'webmap', 'webscene', or 'unknown' on lookup failure.
+ */
+function geopress_arcgis_resolve_item_type( $item_id ) {
+	$item_id = sanitize_text_field( $item_id );
+	if ( '' === $item_id ) {
+		return 'unknown';
+	}
+
+	$cache_key = 'geopress_arcgis_item_type_' . md5( $item_id );
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	$opts   = geopress_arcgis_options();
+	$portal = rtrim( $opts['portal_url'], '/' );
+	$url    = $portal . '/sharing/rest/content/items/' . rawurlencode( $item_id ) . '?f=json';
+
+	$response = wp_remote_get( $url, array( 'timeout' => GEOPRESS_FETCH_TIMEOUT ) );
+	if ( is_wp_error( $response ) ) {
+		return 'unknown';
+	}
+
+	$body = wp_remote_retrieve_body( $response );
+	$data = json_decode( $body, true );
+	if ( ! is_array( $data ) || empty( $data['type'] ) ) {
+		return 'unknown';
+	}
+
+	if ( 'Web Scene' === $data['type'] ) {
+		$type = 'webscene';
+	} elseif ( 'Web Map' === $data['type'] ) {
+		$type = 'webmap';
+	} else {
+		$type = 'unknown';
+	}
+
+	set_transient( $cache_key, $type, DAY_IN_SECONDS );
+	return $type;
+}
+
+/**
+ * Unified ArcGIS map embed. Resolves the item type from the portal and
+ * dispatches to the web-map or web-scene renderer accordingly. Backs the
+ * INSERT_ARCGIS_MAP(item_id[,h,w]) content tag.
+ *
+ * @param string $item_id Portal item ID — may be a web map or a web scene.
+ * @param int    $height  Map height in px (0 = use saved option).
+ * @param int    $width   Map width in px (0 = use saved option).
+ * @return string
+ */
+function geopress_arcgis_map_embed( $item_id, $height = 0, $width = 0 ) {
+	$type = geopress_arcgis_resolve_item_type( $item_id );
+
+	if ( 'webscene' === $type ) {
+		return geopress_arcgis_webscene_embed( $item_id, $height, $width );
+	}
+
+	// Default to a web map for known web maps and for items that can't be
+	// resolved (the SDK will surface a load error if the item is incompatible).
+	return geopress_arcgis_webmap_embed( $item_id, $height, $width );
+}
+
 // ── Standalone map template functions ─────────────────────────────────────────
 
 /**

--- a/includes/class-geopress-maps.php
+++ b/includes/class-geopress-maps.php
@@ -99,6 +99,114 @@ class GeoPress_Maps {
 	}
 }
 
+// ── ArcGIS helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Returns all saved ArcGIS options as an array.
+ *
+ * @return array {
+ *     @type string portal_url           ArcGIS portal URL.
+ *     @type string api_key              ArcGIS Platform API key (may be empty).
+ *     @type string basemap              Basemap style identifier.
+ *     @type string webmap_item_id       Portal item ID for a web map (may be empty).
+ *     @type string webscene_item_id     Portal item ID for a web scene (may be empty).
+ *     @type string feature_layer_url    Feature layer service URL (may be empty).
+ *     @type string feature_layer_item_id Portal item ID for a feature layer (may be empty).
+ * }
+ */
+function geopress_arcgis_options() {
+	return array(
+		'portal_url'             => get_option( '_geopress_arcgis_portal_url', 'https://www.arcgis.com' ),
+		'api_key'                => get_option( '_geopress_arcgis_api_key', '' ),
+		'basemap'                => get_option( '_geopress_arcgis_basemap', 'arcgis/navigation' ),
+		'webmap_item_id'         => get_option( '_geopress_arcgis_webmap_item_id', '' ),
+		'webscene_item_id'       => get_option( '_geopress_arcgis_webscene_item_id', '' ),
+		'feature_layer_url'      => get_option( '_geopress_arcgis_feature_layer_url', '' ),
+		'feature_layer_item_id'  => get_option( '_geopress_arcgis_feature_layer_item_id', '' ),
+	);
+}
+
+/**
+ * Builds the optional <arcgis-feature-layer> child element string.
+ *
+ * If both url and item_id are set, url takes precedence.
+ *
+ * @param string $url     Feature layer service URL.
+ * @param string $item_id Feature layer portal item ID.
+ * @return string
+ */
+function geopress_arcgis_feature_layer_html( $url, $item_id ) {
+	if ( '' !== $url ) {
+		return '<arcgis-feature-layer url="' . esc_url( $url ) . '"></arcgis-feature-layer>';
+	}
+	if ( '' !== $item_id ) {
+		return '<arcgis-feature-layer item-id="' . esc_attr( $item_id ) . '"></arcgis-feature-layer>';
+	}
+	return '';
+}
+
+/**
+ * Returns an ArcGIS web map embed (standalone, not tied to a post location).
+ *
+ * @param string $item_id Portal item ID of the web map.
+ * @param int    $height  Map height in px (0 = use saved option).
+ * @param int    $width   Map width in px (0 = use saved option).
+ * @return string
+ */
+function geopress_arcgis_webmap_embed( $item_id, $height = 0, $width = 0 ) {
+	if ( '' === $item_id ) {
+		return '';
+	}
+	if ( ! $height || ! $width ) {
+		$height = (int) get_option( '_geopress_mapheight', 200 );
+		$width  = (int) get_option( '_geopress_mapwidth', 400 );
+	}
+	$arcgis  = geopress_arcgis_options();
+	$api_key = '' !== $arcgis['api_key'] ? ' api-key="' . esc_attr( $arcgis['api_key'] ) . '"' : '';
+	$zoom    = GeoPress::mapstraction_map_zoom();
+
+	$fl = geopress_arcgis_feature_layer_html( $arcgis['feature_layer_url'], $arcgis['feature_layer_item_id'] );
+
+	return '<!-- GeoPress ArcGIS WebMap -->'
+		. '<arcgis-map item-id="' . esc_attr( $item_id ) . '"'
+		. ' zoom="' . (int) $zoom . '"'
+		. $api_key
+		. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">'
+		. $fl
+		. '<arcgis-zoom position="top-left"></arcgis-zoom>'
+		. '<arcgis-basemap-toggle position="bottom-right"></arcgis-basemap-toggle>'
+		. '</arcgis-map><!-- end GeoPress ArcGIS WebMap -->' . "\n";
+}
+
+/**
+ * Returns an ArcGIS web scene embed (standalone, not tied to a post location).
+ *
+ * @param string $item_id Portal item ID of the web scene.
+ * @param int    $height  Map height in px (0 = use saved option).
+ * @param int    $width   Map width in px (0 = use saved option).
+ * @return string
+ */
+function geopress_arcgis_webscene_embed( $item_id, $height = 0, $width = 0 ) {
+	if ( '' === $item_id ) {
+		return '';
+	}
+	if ( ! $height || ! $width ) {
+		$height = (int) get_option( '_geopress_mapheight', 200 );
+		$width  = (int) get_option( '_geopress_mapwidth', 400 );
+	}
+	$arcgis  = geopress_arcgis_options();
+	$api_key = '' !== $arcgis['api_key'] ? ' api-key="' . esc_attr( $arcgis['api_key'] ) . '"' : '';
+
+	$fl = geopress_arcgis_feature_layer_html( $arcgis['feature_layer_url'], $arcgis['feature_layer_item_id'] );
+
+	return '<!-- GeoPress ArcGIS WebScene -->'
+		. '<arcgis-scene item-id="' . esc_attr( $item_id ) . '"'
+		. $api_key
+		. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">'
+		. $fl
+		. '</arcgis-scene><!-- end GeoPress ArcGIS WebScene -->' . "\n";
+}
+
 // ── Standalone map template functions ─────────────────────────────────────────
 
 /**
@@ -127,6 +235,55 @@ function geopress_map( $height = '', $width = '', $locations = -1, $unique_id = 
 	$locs = $loop_locations
 		? GeoPress::get_loop_locations( $locations )
 		: GeoPress::get_location_posts( $locations );
+
+	// ── ArcGIS Maps SDK v5 path ───────────────────────────────────────────────
+	if ( 'arcgis' === $map_format ) {
+		$arcgis = geopress_arcgis_options();
+
+		$location_data = array();
+		$blog_url      = site_url();
+
+		foreach ( $locs as $posts ) {
+			$loc    = $posts[0];
+			$coords = preg_split( '/\s+/', trim( $loc->coord ) );
+			$lat    = isset( $coords[0] ) ? (float) $coords[0] : 0;
+			$lon    = isset( $coords[1] ) ? (float) $coords[1] : 0;
+
+			$details = esc_html( $loc->name );
+			foreach ( $posts as $post ) {
+				$details .= ' <a href="' . esc_url( $blog_url . '/?p=' . $post->ID ) . '">' . esc_html( $post->post_title ) . '</a>';
+			}
+
+			$location_data[] = array(
+				'lat'     => $lat,
+				'lon'     => $lon,
+				'name'    => $loc->name,
+				'details' => $details,
+			);
+		}
+
+		$api_key = '' !== $arcgis['api_key'] ? ' api-key="' . esc_attr( $arcgis['api_key'] ) . '"' : '';
+		$fl      = geopress_arcgis_feature_layer_html( $arcgis['feature_layer_url'], $arcgis['feature_layer_item_id'] );
+
+		// If a default web map is configured, use it as the base.
+		$item_attr = '' !== $arcgis['webmap_item_id']
+			? ' item-id="' . esc_attr( $arcgis['webmap_item_id'] ) . '"'
+			: ' basemap="' . esc_attr( $arcgis['basemap'] ) . '"';
+
+		$output  = '<!-- GeoPress ArcGIS Map -->';
+		$output .= '<arcgis-map id="geo_map' . esc_attr( $map_id ) . '"'
+			. $item_attr
+			. $api_key
+			. ' data-locations="' . esc_attr( wp_json_encode( $location_data ) ) . '"'
+			. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">';
+		$output .= $fl;
+		$output .= '<arcgis-zoom position="top-left"></arcgis-zoom>';
+		$output .= '<arcgis-basemap-toggle position="bottom-right"></arcgis-basemap-toggle>';
+		$output .= '</arcgis-map><!-- end GeoPress ArcGIS Map -->' . "\n";
+
+		return $output;
+	}
+	// ── End ArcGIS path ───────────────────────────────────────────────────────
 
 	$output  = '<div id="geo_map' . esc_attr( $map_id ) . '" class="mapstraction" style="height: ' . (int) $height . 'px; width: ' . (int) $width . 'px;"></div>' . "\n";
 	$output .= '<!-- GeoPress Map --><script type="text/javascript">' . "\n";
@@ -218,6 +375,50 @@ function geopress_page_map( $height = '', $width = '', $controls = true ) {
 	$map_id       = $post->ID . $geopress_map_index;
 	$map_controls = $controls ? GeoPress::mapstraction_map_controls() : 'false';
 	$geo          = GeoPress::get_geo( $post->ID );
+	$map_format   = GeoPress::mapstraction_map_format( $geo ? $geo->map_format : '' );
+
+	// ── ArcGIS Maps SDK v5 path ───────────────────────────────────────────────
+	if ( 'arcgis' === $map_format ) {
+		$arcgis        = geopress_arcgis_options();
+		$location_data = array();
+
+		foreach ( $children as $key => $value ) {
+			$child_geo = GeoPress::get_geo( (int) $key );
+			if ( ! $child_geo ) {
+				continue;
+			}
+			$coords = preg_split( '/\s+/', trim( $child_geo->coord ) );
+			$lat    = isset( $coords[0] ) ? (float) $coords[0] : 0;
+			$lon    = isset( $coords[1] ) ? (float) $coords[1] : 0;
+			$location_data[] = array(
+				'lat'     => $lat,
+				'lon'     => $lon,
+				'name'    => $child_geo->name,
+				'details' => '',
+			);
+		}
+
+		$api_key   = '' !== $arcgis['api_key'] ? ' api-key="' . esc_attr( $arcgis['api_key'] ) . '"' : '';
+		$fl        = geopress_arcgis_feature_layer_html( $arcgis['feature_layer_url'], $arcgis['feature_layer_item_id'] );
+		$item_attr = '' !== $arcgis['webmap_item_id']
+			? ' item-id="' . esc_attr( $arcgis['webmap_item_id'] ) . '"'
+			: ' basemap="' . esc_attr( $arcgis['basemap'] ) . '"';
+
+		$output  = '<!-- GeoPress ArcGIS Map -->';
+		$output .= '<arcgis-map id="geo_map' . esc_attr( $map_id ) . '"'
+			. $item_attr
+			. $api_key
+			. ' data-locations="' . esc_attr( wp_json_encode( $location_data ) ) . '"'
+			. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">';
+		$output .= $fl;
+		$output .= '<arcgis-zoom position="top-left"></arcgis-zoom>';
+		$output .= '<arcgis-basemap-toggle position="bottom-right"></arcgis-basemap-toggle>';
+		$output .= '</arcgis-map><!-- end GeoPress ArcGIS Map -->' . "\n";
+
+		$geopress_map_index++;
+		return $output;
+	}
+	// ── End ArcGIS path ───────────────────────────────────────────────────────
 
 	$output  = '<div id="geo_map' . esc_attr( $map_id ) . '" class="mapstraction" style="height: ' . (int) $height . 'px; width: ' . (int) $width . 'px;"></div>';
 	$output .= '<!-- GeoPress Map --><script type="text/javascript">';
@@ -275,17 +476,77 @@ function geopress_post_map( $height = '', $width = '', $controls = true, $overla
 		$width  = (int) get_option( '_geopress_mapwidth', 400 );
 	}
 
-	$map_id       = $post->ID . $geopress_map_index;
-	$coords       = preg_split( '/\s+/', trim( $geo->coord ) );
-	$lat          = isset( $coords[0] ) ? (float) $coords[0] : 0;
-	$lon          = isset( $coords[1] ) ? (float) $coords[1] : 0;
+	$map_id     = $post->ID . $geopress_map_index;
+	$coords     = preg_split( '/\s+/', trim( $geo->coord ) );
+	$lat        = isset( $coords[0] ) ? (float) $coords[0] : 0;
+	$lon        = isset( $coords[1] ) ? (float) $coords[1] : 0;
+	$map_format = GeoPress::mapstraction_map_format( $geo->map_format );
+
+	// ── ArcGIS Maps SDK v5 path ───────────────────────────────────────────────
+	if ( 'arcgis' === $map_format ) {
+		$arcgis  = geopress_arcgis_options();
+		$zoom    = GeoPress::mapstraction_map_zoom( $geo->map_zoom );
+		$api_key = '' !== $arcgis['api_key'] ? ' api-key="' . esc_attr( $arcgis['api_key'] ) . '"' : '';
+		$fl      = geopress_arcgis_feature_layer_html( $arcgis['feature_layer_url'], $arcgis['feature_layer_item_id'] );
+
+		if ( '' !== $arcgis['webscene_item_id'] ) {
+			// Web scene (3D): use item-id; marker data attributes still present
+			// so arcgis-map.js can add a point if desired.
+			$output  = '<!-- GeoPress ArcGIS Scene -->';
+			$output .= '<arcgis-scene id="geo_map' . esc_attr( $map_id ) . '"'
+				. ' item-id="' . esc_attr( $arcgis['webscene_item_id'] ) . '"'
+				. $api_key
+				. ' data-lat="' . esc_attr( $lat ) . '"'
+				. ' data-lon="' . esc_attr( $lon ) . '"'
+				. ' data-name="' . esc_attr( $geo->name ) . '"'
+				. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">';
+			$output .= $fl;
+			$output .= '</arcgis-scene><!-- end GeoPress ArcGIS Scene -->' . "\n";
+		} elseif ( '' !== $arcgis['webmap_item_id'] ) {
+			// Web map from portal item.
+			$output  = '<!-- GeoPress ArcGIS WebMap -->';
+			$output .= '<arcgis-map id="geo_map' . esc_attr( $map_id ) . '"'
+				. ' item-id="' . esc_attr( $arcgis['webmap_item_id'] ) . '"'
+				. ' zoom="' . (int) $zoom . '"'
+				. $api_key
+				. ' data-lat="' . esc_attr( $lat ) . '"'
+				. ' data-lon="' . esc_attr( $lon ) . '"'
+				. ' data-name="' . esc_attr( $geo->name ) . '"'
+				. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">';
+			$output .= $fl;
+			$output .= '<arcgis-zoom position="top-left"></arcgis-zoom>';
+			$output .= '<arcgis-basemap-toggle position="bottom-right"></arcgis-basemap-toggle>';
+			$output .= '</arcgis-map><!-- end GeoPress ArcGIS WebMap -->' . "\n";
+		} else {
+			// Coordinate-based map with default basemap.
+			$output  = '<!-- GeoPress ArcGIS Map -->';
+			$output .= '<arcgis-map id="geo_map' . esc_attr( $map_id ) . '"'
+				. ' basemap="' . esc_attr( $arcgis['basemap'] ) . '"'
+				. ' center="' . esc_attr( $lon . ',' . $lat ) . '"'
+				. ' zoom="' . (int) $zoom . '"'
+				. $api_key
+				. ' data-lat="' . esc_attr( $lat ) . '"'
+				. ' data-lon="' . esc_attr( $lon ) . '"'
+				. ' data-name="' . esc_attr( $geo->name ) . '"'
+				. ' style="height:' . (int) $height . 'px; width:' . (int) $width . 'px;">';
+			$output .= $fl;
+			$output .= '<arcgis-zoom position="top-left"></arcgis-zoom>';
+			$output .= '<arcgis-basemap-toggle position="bottom-right"></arcgis-basemap-toggle>';
+			$output .= '</arcgis-map><!-- end GeoPress ArcGIS Map -->' . "\n";
+		}
+
+		$geopress_map_index++;
+		return $output;
+	}
+	// ── End ArcGIS path ───────────────────────────────────────────────────────
+
 	$map_controls = $controls ? GeoPress::mapstraction_map_controls() : 'false';
 
 	$output  = '<div id="geo_map' . esc_attr( $map_id ) . '" class="mapstraction" style="height: ' . (int) $height . 'px; width: ' . (int) $width . 'px;"></div>';
 	$output .= '<!-- GeoPress Map --><script type="text/javascript">';
 	$output .= 'geopress_addEvent(window,"load", function() { geopress_makemap(';
 	$output .= $map_id . ',"' . esc_js( $geo->name ) . '",' . $lat . ',' . $lon . ',"';
-	$output .= esc_js( GeoPress::mapstraction_map_format( $geo->map_format ) ) . '",';
+	$output .= esc_js( $map_format ) . '",';
 	$output .= GeoPress::mapstraction_map_type( $geo->map_type ) . ', ' . $map_controls . ',';
 	$output .= GeoPress::mapstraction_map_zoom( $geo->map_zoom ) . ', "' . esc_js( $geopress_marker ) . '"';
 	$output .= ')';

--- a/includes/class-geopress.php
+++ b/includes/class-geopress.php
@@ -460,30 +460,18 @@ class GeoPress {
 	public static function embed_map_inpost( $content ) {
 		$default_add_map = (int) get_option( '_geopress_default_add_map', 0 );
 
-		// INSERT_ARCGIS_WEBMAP — standalone ArcGIS web map by portal item ID.
-		if ( preg_match( '/INSERT_ARCGIS_WEBMAP/', $content ) ) {
+		// INSERT_ARCGIS_MAP — standalone ArcGIS embed by portal item ID. The item
+		// type (web map vs web scene) is resolved against the configured portal
+		// and cached in a transient, so authors only need a single tag.
+		if ( preg_match( '/INSERT_ARCGIS_MAP/', $content ) ) {
 			$content = preg_replace_callback(
-				'/INSERT_ARCGIS_WEBMAP\(([^,)]+),[ ]?(\d+),[ ]?(\d+)\)/',
-				function ( $m ) { return geopress_arcgis_webmap_embed( trim( $m[1] ), (int) $m[2], (int) $m[3] ); },
+				'/INSERT_ARCGIS_MAP\(([^,)]+),[ ]?(\d+),[ ]?(\d+)\)/',
+				function ( $m ) { return geopress_arcgis_map_embed( trim( $m[1] ), (int) $m[2], (int) $m[3] ); },
 				$content
 			);
 			$content = preg_replace_callback(
-				'/INSERT_ARCGIS_WEBMAP\(([^)]+)\)/',
-				function ( $m ) { return geopress_arcgis_webmap_embed( trim( $m[1] ) ); },
-				$content
-			);
-		}
-
-		// INSERT_ARCGIS_WEBSCENE — standalone ArcGIS 3D web scene by portal item ID.
-		if ( preg_match( '/INSERT_ARCGIS_WEBSCENE/', $content ) ) {
-			$content = preg_replace_callback(
-				'/INSERT_ARCGIS_WEBSCENE\(([^,)]+),[ ]?(\d+),[ ]?(\d+)\)/',
-				function ( $m ) { return geopress_arcgis_webscene_embed( trim( $m[1] ), (int) $m[2], (int) $m[3] ); },
-				$content
-			);
-			$content = preg_replace_callback(
-				'/INSERT_ARCGIS_WEBSCENE\(([^)]+)\)/',
-				function ( $m ) { return geopress_arcgis_webscene_embed( trim( $m[1] ) ); },
+				'/INSERT_ARCGIS_MAP\(([^)]+)\)/',
+				function ( $m ) { return geopress_arcgis_map_embed( trim( $m[1] ) ); },
 				$content
 			);
 		}

--- a/includes/class-geopress.php
+++ b/includes/class-geopress.php
@@ -66,7 +66,7 @@ class GeoPress {
 		// ArcGIS Maps SDK v5 options.
 		add_option( '_geopress_arcgis_portal_url',          'https://www.arcgis.com' );
 		add_option( '_geopress_arcgis_api_key',             '' );
-		add_option( '_geopress_arcgis_basemap',             'arcgis/navigation' );
+		add_option( '_geopress_arcgis_basemap',             'osm' );
 		add_option( '_geopress_arcgis_webmap_item_id',      '' );
 		add_option( '_geopress_arcgis_webscene_item_id',    '' );
 		add_option( '_geopress_arcgis_feature_layer_url',   '' );
@@ -734,13 +734,13 @@ class GeoPress {
 		// ArcGIS Maps SDK v5 — web components bundle and our ES-module helper.
 		wp_register_style(
 			'geopress-arcgis-css',
-			'https://js.arcgis.com/5.x/esri/themes/light/main.css',
+			'https://js.arcgis.com/5.0/esri/themes/light/main.css',
 			array(),
 			null
 		);
 		wp_register_script(
 			'geopress-arcgis-components',
-			'https://js.arcgis.com/map-components/5.x/arcgis-map-components.esm.js',
+			'https://js.arcgis.com/5.0/',
 			array(),
 			null,
 			false

--- a/includes/class-geopress.php
+++ b/includes/class-geopress.php
@@ -63,6 +63,15 @@ class GeoPress {
 		add_option( '_geopress_default_zoom_level','11' );
 		add_option( '_geopress_google_apikey',     '' );
 
+		// ArcGIS Maps SDK v5 options.
+		add_option( '_geopress_arcgis_portal_url',          'https://www.arcgis.com' );
+		add_option( '_geopress_arcgis_api_key',             '' );
+		add_option( '_geopress_arcgis_basemap',             'arcgis/navigation' );
+		add_option( '_geopress_arcgis_webmap_item_id',      '' );
+		add_option( '_geopress_arcgis_webscene_item_id',    '' );
+		add_option( '_geopress_arcgis_feature_layer_url',   '' );
+		add_option( '_geopress_arcgis_feature_layer_item_id', '' );
+
 		$ping_sites = get_option( 'ping_sites', '' );
 		if ( false === strpos( $ping_sites, 'mapufacture' ) ) {
 			update_option( 'ping_sites', $ping_sites . "\nhttps://mapufacture.com/georss/ping/api" );
@@ -451,6 +460,34 @@ class GeoPress {
 	public static function embed_map_inpost( $content ) {
 		$default_add_map = (int) get_option( '_geopress_default_add_map', 0 );
 
+		// INSERT_ARCGIS_WEBMAP — standalone ArcGIS web map by portal item ID.
+		if ( preg_match( '/INSERT_ARCGIS_WEBMAP/', $content ) ) {
+			$content = preg_replace_callback(
+				'/INSERT_ARCGIS_WEBMAP\(([^,)]+),[ ]?(\d+),[ ]?(\d+)\)/',
+				function ( $m ) { return geopress_arcgis_webmap_embed( trim( $m[1] ), (int) $m[2], (int) $m[3] ); },
+				$content
+			);
+			$content = preg_replace_callback(
+				'/INSERT_ARCGIS_WEBMAP\(([^)]+)\)/',
+				function ( $m ) { return geopress_arcgis_webmap_embed( trim( $m[1] ) ); },
+				$content
+			);
+		}
+
+		// INSERT_ARCGIS_WEBSCENE — standalone ArcGIS 3D web scene by portal item ID.
+		if ( preg_match( '/INSERT_ARCGIS_WEBSCENE/', $content ) ) {
+			$content = preg_replace_callback(
+				'/INSERT_ARCGIS_WEBSCENE\(([^,)]+),[ ]?(\d+),[ ]?(\d+)\)/',
+				function ( $m ) { return geopress_arcgis_webscene_embed( trim( $m[1] ), (int) $m[2], (int) $m[3] ); },
+				$content
+			);
+			$content = preg_replace_callback(
+				'/INSERT_ARCGIS_WEBSCENE\(([^)]+)\)/',
+				function ( $m ) { return geopress_arcgis_webscene_embed( trim( $m[1] ) ); },
+				$content
+			);
+		}
+
 		if ( preg_match( '/INSERT_MAP/', $content ) ) {
 			// INSERT_MAP(h,w,url)
 			$content = preg_replace_callback(
@@ -643,8 +680,10 @@ class GeoPress {
 	 */
 	public static function enqueue_scripts() {
 		self::register_scripts();
-		wp_enqueue_script( 'geopress-mapstraction' );
-		wp_enqueue_script( 'geopress-js' );
+		if ( 'arcgis' !== get_option( '_geopress_map_format', 'openlayers' ) ) {
+			wp_enqueue_script( 'geopress-mapstraction' );
+			wp_enqueue_script( 'geopress-js' );
+		}
 		self::enqueue_map_api_scripts();
 	}
 
@@ -660,6 +699,7 @@ class GeoPress {
 			return;
 		}
 		self::register_scripts();
+		// Always enqueue Mapstraction for the admin location-picker regardless of format.
 		wp_enqueue_script( 'geopress-mapstraction' );
 		wp_enqueue_script( 'geopress-js' );
 		self::enqueue_map_api_scripts();
@@ -690,6 +730,41 @@ class GeoPress {
 			GEOPRESS_VERSION,
 			false
 		);
+
+		// ArcGIS Maps SDK v5 — web components bundle and our ES-module helper.
+		wp_register_style(
+			'geopress-arcgis-css',
+			'https://js.arcgis.com/5.x/esri/themes/light/main.css',
+			array(),
+			null
+		);
+		wp_register_script(
+			'geopress-arcgis-components',
+			'https://js.arcgis.com/map-components/5.x/arcgis-map-components.esm.js',
+			array(),
+			null,
+			false
+		);
+		wp_register_script(
+			'geopress-arcgis-js',
+			GEOPRESS_URL . 'arcgis-map.js',
+			array( 'geopress-arcgis-components' ),
+			GEOPRESS_VERSION,
+			false
+		);
+
+		// Both ArcGIS scripts must be served as ES modules.
+		add_filter(
+			'script_loader_tag',
+			function ( $tag, $handle ) {
+				if ( in_array( $handle, array( 'geopress-arcgis-components', 'geopress-arcgis-js' ), true ) ) {
+					return str_replace( ' src=', ' type="module" src=', $tag );
+				}
+				return $tag;
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -697,6 +772,24 @@ class GeoPress {
 	 */
 	private static function enqueue_map_api_scripts() {
 		$map_format = get_option( '_geopress_map_format', 'openlayers' );
+
+		// ArcGIS Maps SDK v5 — web components path (bypasses Mapstraction entirely).
+		if ( 'arcgis' === $map_format ) {
+			wp_enqueue_style( 'geopress-arcgis-css' );
+			wp_enqueue_script( 'geopress-arcgis-components' );
+			wp_enqueue_script( 'geopress-arcgis-js' );
+			wp_add_inline_script(
+				'geopress-arcgis-js',
+				'window.geopressArcGISConfig = ' . wp_json_encode(
+					array(
+						'apiKey'    => get_option( '_geopress_arcgis_api_key', '' ),
+						'portalUrl' => get_option( '_geopress_arcgis_portal_url', 'https://www.arcgis.com' ),
+					)
+				) . ';',
+				'before'
+			);
+			return;
+		}
 
 		// Enqueue the OpenLayers library only when it is the active provider.
 		if ( in_array( $map_format, array( 'openlayers', 'openstreetmap' ), true ) ) {

--- a/includes/class-geopress.php
+++ b/includes/class-geopress.php
@@ -219,7 +219,7 @@ class GeoPress {
 		global $wpdb;
 
 		$loc_id = (int) $loc_id;
-		if ( ! $loc_id ) {
+		if ( $loc_id <= 0 ) {
 			return null;
 		}
 

--- a/tests/Unit/Feed/AtomEntryTest.php
+++ b/tests/Unit/Feed/AtomEntryTest.php
@@ -16,7 +16,9 @@ class AtomEntryTest extends TestCase {
         $GLOBALS['post']  = $post;
 
         $wpdb         = \Mockery::mock( 'wpdb' );
-        $wpdb->prefix = 'wp_';
+        $wpdb->prefix   = 'wp_';
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->posts    = 'wp_posts';
         $GLOBALS['wpdb'] = $wpdb;
     }
 

--- a/tests/Unit/Feed/Rss2ItemTest.php
+++ b/tests/Unit/Feed/Rss2ItemTest.php
@@ -16,7 +16,9 @@ class Rss2ItemTest extends TestCase {
         $GLOBALS['post']  = $post;
 
         $wpdb         = \Mockery::mock( 'wpdb' );
-        $wpdb->prefix = 'wp_';
+        $wpdb->prefix   = 'wp_';
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->posts    = 'wp_posts';
         $GLOBALS['wpdb'] = $wpdb;
     }
 

--- a/tests/Unit/Maps/ArcGISTest.php
+++ b/tests/Unit/Maps/ArcGISTest.php
@@ -87,6 +87,72 @@ class ArcGISTest extends TestCase {
         $this->assertStringContainsString( 'width:500px',            $html );
     }
 
+    public function test_resolve_item_type_returns_webmap_for_web_map_response(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+        Functions\when( 'get_transient' )->justReturn( false );
+        Functions\when( 'set_transient' )->justReturn( true );
+        Functions\when( 'wp_remote_get' )->justReturn( array(
+            'body'     => '{"type":"Web Map","title":"London"}',
+            'response' => array( 'code' => 200 ),
+        ) );
+
+        $this->assertSame( 'webmap', geopress_arcgis_resolve_item_type( 'abc123' ) );
+    }
+
+    public function test_resolve_item_type_returns_webscene_for_web_scene_response(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+        Functions\when( 'get_transient' )->justReturn( false );
+        Functions\when( 'set_transient' )->justReturn( true );
+        Functions\when( 'wp_remote_get' )->justReturn( array(
+            'body'     => '{"type":"Web Scene","title":"3D city"}',
+            'response' => array( 'code' => 200 ),
+        ) );
+
+        $this->assertSame( 'webscene', geopress_arcgis_resolve_item_type( 'scene789' ) );
+    }
+
+    public function test_resolve_item_type_returns_unknown_for_other_item_types(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+        Functions\when( 'get_transient' )->justReturn( false );
+        Functions\when( 'set_transient' )->justReturn( true );
+        Functions\when( 'wp_remote_get' )->justReturn( array(
+            'body'     => '{"type":"Feature Service"}',
+            'response' => array( 'code' => 200 ),
+        ) );
+
+        $this->assertSame( 'unknown', geopress_arcgis_resolve_item_type( 'feat456' ) );
+    }
+
+    public function test_resolve_item_type_uses_transient_cache(): void {
+        Functions\when( 'get_transient' )->justReturn( 'webscene' );
+        // No wp_remote_get stub on purpose: a cache hit must not touch the network.
+        Functions\expect( 'wp_remote_get' )->never();
+
+        $this->assertSame( 'webscene', geopress_arcgis_resolve_item_type( 'cached' ) );
+    }
+
+    public function test_map_embed_renders_webscene_when_item_is_webscene(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+        Functions\when( 'get_transient' )->justReturn( 'webscene' );
+
+        $html = geopress_arcgis_map_embed( 'scene789', 300, 500 );
+
+        $this->assertStringContainsString( '<arcgis-scene ',  $html );
+        $this->assertStringContainsString( 'item-id="scene789"', $html );
+        $this->assertStringNotContainsString( '<arcgis-map ', $html );
+    }
+
+    public function test_map_embed_defaults_to_webmap_for_unknown_items(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+        Functions\when( 'get_transient' )->justReturn( 'unknown' );
+
+        $html = geopress_arcgis_map_embed( 'mystery', 300, 500 );
+
+        $this->assertStringContainsString( '<arcgis-map ',     $html );
+        $this->assertStringContainsString( 'item-id="mystery"', $html );
+        $this->assertStringNotContainsString( '<arcgis-scene ', $html );
+    }
+
     public function test_enqueue_scripts_injects_arcgis_config_when_provider_is_arcgis(): void {
         Functions\when( 'get_option' )->alias( $this->optionResolver( array(
             '_geopress_map_format'        => 'arcgis',

--- a/tests/Unit/Maps/ArcGISTest.php
+++ b/tests/Unit/Maps/ArcGISTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for the ArcGIS Maps SDK 5.0 provider.
+ *
+ * Covers the pure option-reading helpers, feature-layer HTML, the
+ * standalone web-map embed, and the front-end config injection performed
+ * by GeoPress::enqueue_scripts() when the provider is set to 'arcgis'.
+ */
+
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use Brain\Monkey\Functions;
+
+class ArcGISTest extends TestCase {
+
+    /**
+     * Returns a callable to drive Functions\when('get_option')->alias() that
+     * resolves $key from the supplied map, falling back to the test's $default.
+     *
+     * @param array $values  Map of option key => stored value.
+     */
+    private function optionResolver( array $values ): callable {
+        return function ( $key, $default = false ) use ( $values ) {
+            return array_key_exists( $key, $values ) ? $values[ $key ] : $default;
+        };
+    }
+
+    public function test_arcgis_options_returns_osm_default_basemap(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+
+        $opts = geopress_arcgis_options();
+
+        $this->assertSame( 'https://www.arcgis.com', $opts['portal_url'] );
+        $this->assertSame( '',                       $opts['api_key'] );
+        $this->assertSame( 'osm',                    $opts['basemap'] );
+        $this->assertSame( '',                       $opts['webmap_item_id'] );
+        $this->assertSame( '',                       $opts['webscene_item_id'] );
+        $this->assertSame( '',                       $opts['feature_layer_url'] );
+        $this->assertSame( '',                       $opts['feature_layer_item_id'] );
+    }
+
+    public function test_arcgis_options_reflects_stored_values(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array(
+            '_geopress_arcgis_portal_url'    => 'https://portal.example.com',
+            '_geopress_arcgis_api_key'       => 'AAPK-test-key',
+            '_geopress_arcgis_basemap'       => 'arcgis/imagery',
+            '_geopress_arcgis_webmap_item_id' => 'abc123',
+        ) ) );
+
+        $opts = geopress_arcgis_options();
+
+        $this->assertSame( 'https://portal.example.com', $opts['portal_url'] );
+        $this->assertSame( 'AAPK-test-key',              $opts['api_key'] );
+        $this->assertSame( 'arcgis/imagery',             $opts['basemap'] );
+        $this->assertSame( 'abc123',                     $opts['webmap_item_id'] );
+    }
+
+    public function test_feature_layer_html_returns_url_variant(): void {
+        $html = geopress_arcgis_feature_layer_html( 'https://services.arcgis.com/abc/FeatureServer/0', '' );
+
+        $this->assertStringContainsString( '<arcgis-feature-layer', $html );
+        $this->assertStringContainsString( 'url="https://services.arcgis.com/abc/FeatureServer/0"', $html );
+        $this->assertStringNotContainsString( 'item-id=', $html );
+    }
+
+    public function test_feature_layer_html_returns_item_id_variant(): void {
+        $html = geopress_arcgis_feature_layer_html( '', 'feature-item-7' );
+
+        $this->assertStringContainsString( '<arcgis-feature-layer', $html );
+        $this->assertStringContainsString( 'item-id="feature-item-7"', $html );
+        $this->assertStringNotContainsString( 'url=', $html );
+    }
+
+    public function test_feature_layer_html_returns_empty_when_no_inputs(): void {
+        $this->assertSame( '', geopress_arcgis_feature_layer_html( '', '' ) );
+    }
+
+    public function test_webmap_embed_uses_item_id_and_basemap_toggle(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array() ) );
+
+        $html = geopress_arcgis_webmap_embed( 'webmap-xyz', 300, 500 );
+
+        $this->assertStringContainsString( 'item-id="webmap-xyz"', $html );
+        $this->assertStringContainsString( '<arcgis-map ',           $html );
+        $this->assertStringContainsString( '<arcgis-zoom ',          $html );
+        $this->assertStringContainsString( '<arcgis-basemap-toggle ', $html );
+        $this->assertStringContainsString( 'height:300px',           $html );
+        $this->assertStringContainsString( 'width:500px',            $html );
+    }
+
+    public function test_enqueue_scripts_injects_arcgis_config_when_provider_is_arcgis(): void {
+        Functions\when( 'get_option' )->alias( $this->optionResolver( array(
+            '_geopress_map_format'        => 'arcgis',
+            '_geopress_arcgis_api_key'    => 'AAPK-test-key',
+            '_geopress_arcgis_portal_url' => 'https://portal.example.com',
+        ) ) );
+
+        // No-op handles we don't care about asserting on.
+        Functions\when( 'wp_register_script' )->justReturn( true );
+        Functions\when( 'wp_register_style' )->justReturn( true );
+        Functions\when( 'wp_enqueue_script' )->justReturn( null );
+        Functions\when( 'wp_enqueue_style' )->justReturn( null );
+        Functions\when( 'add_filter' )->justReturn( true );
+        Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+        $captured = array();
+        Functions\expect( 'wp_add_inline_script' )
+            ->once()
+            ->with( 'geopress-arcgis-js', \Mockery::capture( $captured ), 'before' );
+
+        GeoPress::enqueue_scripts();
+
+        $this->assertStringContainsString( 'window.geopressArcGISConfig', $captured );
+        $this->assertStringContainsString( '"apiKey":"AAPK-test-key"',    $captured );
+        $this->assertStringContainsString( '"portalUrl":"https:\/\/portal.example.com"', $captured );
+    }
+}

--- a/tests/Unit/Template/HasLocationTest.php
+++ b/tests/Unit/Template/HasLocationTest.php
@@ -16,7 +16,9 @@ class HasLocationTest extends TestCase {
         $GLOBALS['post'] = $post;
 
         $wpdb         = \Mockery::mock( 'wpdb' );
-        $wpdb->prefix = 'wp_';
+        $wpdb->prefix   = 'wp_';
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->posts    = 'wp_posts';
         $GLOBALS['wpdb'] = $wpdb;
     }
 

--- a/tests/Unit/Template/TheAddressTest.php
+++ b/tests/Unit/Template/TheAddressTest.php
@@ -16,7 +16,9 @@ class TheAddressTest extends TestCase {
         $GLOBALS['post']  = $post;
 
         $wpdb         = \Mockery::mock( 'wpdb' );
-        $wpdb->prefix = 'wp_';
+        $wpdb->prefix   = 'wp_';
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->posts    = 'wp_posts';
         $GLOBALS['wpdb'] = $wpdb;
     }
 

--- a/tests/Unit/Template/TheCoordTest.php
+++ b/tests/Unit/Template/TheCoordTest.php
@@ -16,7 +16,9 @@ class TheCoordTest extends TestCase {
         $GLOBALS['post']  = $post;
 
         $wpdb         = \Mockery::mock( 'wpdb' );
-        $wpdb->prefix = 'wp_';
+        $wpdb->prefix   = 'wp_';
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->posts    = 'wp_posts';
         $GLOBALS['wpdb'] = $wpdb;
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,12 +28,12 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
-define( 'GEOPRESS_VERSION',              '3.0' );
+define( 'GEOPRESS_VERSION',              '3.1' );
 define( 'GEOPRESS_DIR',                  dirname( __DIR__ ) . '/' );
 define( 'GEOPRESS_URL',                  'http://example.com/wp-content/plugins/geopress/' );
 define( 'GEOPRESS_BASENAME',             'geopress/geopress.php' );
 define( 'GEOPRESS_FETCH_TIMEOUT',        5 );
-define( 'GEOPRESS_USER_AGENT',           'GeoPress/3.0' );
+define( 'GEOPRESS_USER_AGENT',           'GeoPress/3.1' );
 define( 'GEOPRESS_GOOGLE_GEOCODER',      'https://maps.google.com/maps/geo?q=' );
 define( 'GEOPRESS_GOOGLE_REGEXP',        '<coordinates>(.*),(.*),0</coordinates>' );
 define( 'GEOPRESS_YAHOO_REGEXP',         '<Latitude>(.*)<\/Latitude>.*<Longitude>(.*)<\/Longitude>' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,13 +7,22 @@
  * GeoPress calls so unit tests can run without a real WordPress installation.
  */
 
-// Composer autoloader — required before anything else.
-$autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';
-if ( ! file_exists( $autoloader ) ) {
+// Patchwork MUST load before anything else: it registers a stream wrapper that
+// instruments every subsequent require/include so Brain Monkey can later
+// redefine functions in those files. If we let Composer's autoloader pull
+// Patchwork in via its `files` section, the autoloader itself runs un-
+// instrumented and any WP-function stubs declared during bootstrap throw
+// "DefinedTooEarly". Patchwork.php is idempotent: composer's later autoload
+// will see it as already loaded and skip it.
+$patchwork = dirname( __DIR__ ) . '/vendor/antecedent/patchwork/Patchwork.php';
+if ( ! file_exists( $patchwork ) ) {
     echo "Run `composer install` before running the tests.\n";
     exit( 1 );
 }
-require_once $autoloader;
+require_once $patchwork;
+
+// Composer autoloader — Brain Monkey, Mockery, etc.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 // Plugin constants needed by the includes files.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,95 +42,12 @@ define( 'GEOPRESS_YAHOO_ANNOTATEDMAPS',  'https://api.maps.yahoo.com/Maps/V1/Ann
 define( 'GEOPRESS_YAHOO_EMBEDPNGMAPURL', 'https://api.local.yahoo.com/MapsService/V1/mapImage?appid=geocodewordpress&' );
 
 // ── WordPress function stubs ───────────────────────────────────────────────────
-// These are minimal stubs so the plugin's include files can be loaded.
-// Tests use Brain Monkey to set expectations on these stubs per-test.
+// Stubs live in a separate file required AFTER the Composer autoloader so that
+// Patchwork (loaded transitively via Brain Monkey) can instrument the
+// definitions. Defining them inline here triggers Patchwork's "DefinedTooEarly"
+// error: Patchwork only instruments files required after it has been loaded.
 
-if ( ! function_exists( 'sanitize_text_field' ) ) {
-    function sanitize_text_field( $str ) { return strip_tags( trim( $str ) ); }
-}
-if ( ! function_exists( 'sanitize_key' ) ) {
-    function sanitize_key( $str ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', $str ) ); }
-}
-if ( ! function_exists( 'esc_html' ) ) {
-    function esc_html( $str ) { return htmlspecialchars( $str, ENT_QUOTES, 'UTF-8' ); }
-}
-if ( ! function_exists( 'esc_attr' ) ) {
-    function esc_attr( $str ) { return htmlspecialchars( $str, ENT_QUOTES, 'UTF-8' ); }
-}
-if ( ! function_exists( 'esc_url' ) ) {
-    function esc_url( $url ) { return filter_var( $url, FILTER_SANITIZE_URL ) ?: ''; }
-}
-if ( ! function_exists( 'esc_url_raw' ) ) {
-    function esc_url_raw( $url ) { return filter_var( $url, FILTER_SANITIZE_URL ) ?: ''; }
-}
-if ( ! function_exists( 'esc_js' ) ) {
-    function esc_js( $str ) { return addslashes( $str ); }
-}
-if ( ! function_exists( 'wp_unslash' ) ) {
-    function wp_unslash( $value ) {
-        return is_array( $value ) ? array_map( 'wp_unslash', $value ) : stripslashes( $value );
-    }
-}
-if ( ! function_exists( 'absint' ) ) {
-    function absint( $n ) { return abs( (int) $n ); }
-}
-if ( ! function_exists( 'add_option' ) ) {
-    function add_option( $key, $value = '' ) {}
-}
-if ( ! function_exists( 'update_option' ) ) {
-    function update_option( $key, $value ) {}
-}
-if ( ! function_exists( 'get_option' ) ) {
-    function get_option( $key, $default = false ) { return $default; }
-}
-if ( ! function_exists( 'get_post_meta' ) ) {
-    function get_post_meta( $post_id, $key = '', $single = false ) { return $single ? '' : array(); }
-}
-if ( ! function_exists( 'update_post_meta' ) ) {
-    function update_post_meta( $post_id, $key, $value ) { return true; }
-}
-if ( ! function_exists( 'add_post_meta' ) ) {
-    function add_post_meta( $post_id, $key, $value ) { return 1; }
-}
-if ( ! function_exists( 'wp_verify_nonce' ) ) {
-    function wp_verify_nonce( $nonce, $action = -1 ) { return 1; }
-}
-if ( ! function_exists( 'current_user_can' ) ) {
-    function current_user_can( $cap ) { return true; }
-}
-if ( ! function_exists( 'get_post' ) ) {
-    function get_post( $post_id ) { return null; }
-}
-if ( ! function_exists( 'is_single' ) ) {
-    function is_single() { return false; }
-}
-if ( ! function_exists( 'is_feed' ) ) {
-    function is_feed() { return false; }
-}
-if ( ! function_exists( 'home_url' ) ) {
-    function home_url( $path = '/' ) { return 'http://example.com' . $path; }
-}
-if ( ! function_exists( 'site_url' ) ) {
-    function site_url( $path = '' ) { return 'http://example.com' . $path; }
-}
-if ( ! function_exists( 'add_query_arg' ) ) {
-    function add_query_arg( $args, $url = '' ) { return $url . '?' . http_build_query( $args ); }
-}
-if ( ! function_exists( 'wp_rand' ) ) {
-    function wp_rand( $min = 0, $max = PHP_INT_MAX ) { return rand( $min, $max ); }
-}
-if ( ! function_exists( 'dbDelta' ) ) {
-    function dbDelta( $sql ) {}
-}
-if ( ! function_exists( 'wp_remote_get' ) ) {
-    function wp_remote_get( $url, $args = array() ) { return array( 'body' => '', 'response' => array( 'code' => 200 ) ); }
-}
-if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
-    function wp_remote_retrieve_body( $response ) { return is_array( $response ) ? ( $response['body'] ?? '' ) : ''; }
-}
-if ( ! function_exists( 'is_wp_error' ) ) {
-    function is_wp_error( $thing ) { return false; }
-}
+require_once __DIR__ . '/wp-stubs.php';
 
 // ── Load plugin classes (no WordPress bootstrap needed) ───────────────────────
 

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Minimal WordPress function stubs for the GeoPress unit-test suite.
+ *
+ * This file is loaded by tests/bootstrap.php AFTER the Composer autoloader,
+ * which lets Patchwork (loaded via Brain Monkey) instrument these definitions
+ * so individual tests can redefine them with Brain\Monkey\Functions\when()
+ * and ::expect(). Defining the stubs inline in bootstrap.php triggers
+ * Patchwork's "DefinedTooEarly" error because Patchwork cannot instrument
+ * functions defined inside an already-running script — only those declared
+ * in a file required after Patchwork is loaded.
+ */
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) { return strip_tags( trim( $str ) ); }
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+    function sanitize_key( $str ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', $str ) ); }
+}
+if ( ! function_exists( 'esc_html' ) ) {
+    function esc_html( $str ) { return htmlspecialchars( $str, ENT_QUOTES, 'UTF-8' ); }
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+    function esc_attr( $str ) { return htmlspecialchars( $str, ENT_QUOTES, 'UTF-8' ); }
+}
+if ( ! function_exists( 'esc_url' ) ) {
+    function esc_url( $url ) { return filter_var( $url, FILTER_SANITIZE_URL ) ?: ''; }
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+    function esc_url_raw( $url ) { return filter_var( $url, FILTER_SANITIZE_URL ) ?: ''; }
+}
+if ( ! function_exists( 'esc_js' ) ) {
+    function esc_js( $str ) { return addslashes( $str ); }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        return is_array( $value ) ? array_map( 'wp_unslash', $value ) : stripslashes( $value );
+    }
+}
+if ( ! function_exists( 'absint' ) ) {
+    function absint( $n ) { return abs( (int) $n ); }
+}
+if ( ! function_exists( 'add_option' ) ) {
+    function add_option( $key, $value = '' ) {}
+}
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( $key, $value ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+    function get_option( $key, $default = false ) { return $default; }
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+    function get_post_meta( $post_id, $key = '', $single = false ) { return $single ? '' : array(); }
+}
+if ( ! function_exists( 'update_post_meta' ) ) {
+    function update_post_meta( $post_id, $key, $value ) { return true; }
+}
+if ( ! function_exists( 'add_post_meta' ) ) {
+    function add_post_meta( $post_id, $key, $value ) { return 1; }
+}
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+    function wp_verify_nonce( $nonce, $action = -1 ) { return 1; }
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+    function current_user_can( $cap ) { return true; }
+}
+if ( ! function_exists( 'get_post' ) ) {
+    function get_post( $post_id ) { return null; }
+}
+if ( ! function_exists( 'is_single' ) ) {
+    function is_single() { return false; }
+}
+if ( ! function_exists( 'is_feed' ) ) {
+    function is_feed() { return false; }
+}
+if ( ! function_exists( 'home_url' ) ) {
+    function home_url( $path = '/' ) { return 'http://example.com' . $path; }
+}
+if ( ! function_exists( 'site_url' ) ) {
+    function site_url( $path = '' ) { return 'http://example.com' . $path; }
+}
+if ( ! function_exists( 'add_query_arg' ) ) {
+    function add_query_arg( $args, $url = '' ) { return $url . '?' . http_build_query( $args ); }
+}
+if ( ! function_exists( 'wp_rand' ) ) {
+    function wp_rand( $min = 0, $max = PHP_INT_MAX ) { return rand( $min, $max ); }
+}
+if ( ! function_exists( 'dbDelta' ) ) {
+    function dbDelta( $sql ) {}
+}
+if ( ! function_exists( 'wp_remote_get' ) ) {
+    function wp_remote_get( $url, $args = array() ) { return array( 'body' => '', 'response' => array( 'code' => 200 ) ); }
+}
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+    function wp_remote_retrieve_body( $response ) { return is_array( $response ) ? ( $response['body'] ?? '' ) : ''; }
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+    function is_wp_error( $thing ) { return false; }
+}

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -97,3 +97,12 @@ if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
 if ( ! function_exists( 'is_wp_error' ) ) {
     function is_wp_error( $thing ) { return false; }
 }
+if ( ! function_exists( 'get_transient' ) ) {
+    function get_transient( $key ) { return false; }
+}
+if ( ! function_exists( 'set_transient' ) ) {
+    function set_transient( $key, $value, $expiration = 0 ) { return true; }
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+    define( 'DAY_IN_SECONDS', 86400 );
+}


### PR DESCRIPTION
## Summary

Adds the **ArcGIS Maps SDK for JavaScript 5.0** as a new GeoPress map provider — point maps, web maps and 3D web scenes by portal item ID, feature-layer overlays, and a new unified `INSERT_ARCGIS_MAP(item_id)` content tag that auto-resolves to the right component. Defaults to OpenStreetMap so the provider works with **no API key required**.

Salvages the work from `claude/arcgis-advanced-mapping-9kh3A` (which was built on a pre-3.0 base and couldn't merge cleanly) by cherry-picking the ArcGIS commit onto `master` and reconciling with the released 3.0 architecture.

**Scope:** 6 commits · `2126488..fd05949`

## Highlights

### ArcGIS provider — declarative, no build step
- `arcgis` joins the Map Format dropdown (`google` / `microsoft` / `openstreetmap` / `openlayers` / **`arcgis`**). Picking it bypasses Mapstraction entirely.
- Uses the SDK's web components: `<arcgis-map>`, `<arcgis-scene>`, `<arcgis-feature-layer>`. Single-point maps carry `data-lat` / `data-lon`; multi-location maps carry `data-locations` JSON. `arcgis-map.js` attaches an `arcgisViewReadyChange` listener and adds `Graphic`s with `view.goTo(view.graphics.toArray())` for auto-fit.

### Module loading: single CDN entry + `$arcgis.import()`
- Loads `https://js.arcgis.com/5.0/` as `type="module"` via a `script_loader_tag` filter — the 5.0 module-based entry that registers all web components and exposes the global `$arcgis.import()`.
- `arcgis-map.js` pulls modules at runtime:
  ```js
  const [{ default: Graphic }, { default: esriConfig }] = await Promise.all([
      $arcgis.import("@arcgis/core/Graphic.js"),
      $arcgis.import("@arcgis/core/config.js"),
  ]);
  ```
- Includes a readiness guard so the module can be loaded before the SDK bootstrap finishes attaching `$arcgis` to `window`.
- *(Replaces the original branch's deep-CDN imports like `https://js.arcgis.com/5.x/@arcgis/core/Graphic.js`, which were not a documented pattern.)*

### Basemap & API-key model
- Default basemap is **`osm`** — no API key needed. The provider works out of the box.
- Optional `_geopress_arcgis_api_key` unlocks Esri basemaps and private portal content; `_geopress_arcgis_portal_url` supports ArcGIS Enterprise.
- API key + portal URL are injected via `wp_add_inline_script` as `window.geopressArcGISConfig`; `arcgis-map.js` applies them to `esriConfig` before any view is created.

### Web maps, 3D scenes, feature layers — one tag
- `Web Map Item ID`, `Web Scene Item ID`, and `Feature Layer URL / Item ID` are first-class admin options on the Maps page.
- **A single content tag: `INSERT_ARCGIS_MAP(item_id[,h,w])`.** The item type (web map vs web scene) is resolved at render time by hitting `{portal}/sharing/rest/content/items/{id}?f=json`, and the result is cached in a transient for a day — so the lookup costs one HTTP request per item, ever. The tag then emits `<arcgis-map>` for web maps or `<arcgis-scene>` for 3D scenes. Unresolvable items default to `<arcgis-map>` and let the SDK surface a load error.

## Bundled fix: the pre-existing PHPUnit suite

The 3.0 suite was broken in this environment — every test errored with `Patchwork: DefinedTooEarly: get_post_meta() included before Patchwork`. The fix is independent of ArcGIS but landed here so ArcGIS unit tests could actually run:

1. **Patchwork load order.** `tests/bootstrap.php` was loading the Composer autoloader and then defining WP function stubs inline. Patchwork can't instrument functions declared in an already-running script. Now `Patchwork.php` is `require`d explicitly first, the autoloader second, and the stubs moved into `tests/wp-stubs.php`.
2. **`$wpdb` mock gaps.** 5 test files set `$wpdb->prefix` but not `$wpdb->postmeta` / `$wpdb->posts`, which `get_geo()` reads.
3. **`get_location()` negative-ID bug** uncovered once the suite ran: `if ( ! $loc_id )` is `true` for `-5` (negative integers are truthy). Tightened to `$loc_id <= 0`, matching the existing `test_returns_null_for_negative_id`.

**Result: 50 tests, 116 assertions, 0 errors** (was 32 errors before this PR; 13 of the 50 are new ArcGIS tests, including the resolver/dispatcher coverage).

## Files

| File | Change |
|------|--------|
| `arcgis-map.js` | NEW — ES module: `$arcgis.import()` readiness guard, single-point + multi-location graphics placement |
| `includes/class-geopress.php` | ArcGIS option defaults at install; provider branch in `enqueue_map_api_scripts()`; `script_loader_tag` filter for `type="module"`; single `INSERT_ARCGIS_MAP` handler; `get_location()` negative-ID fix |
| `includes/class-geopress-admin.php` | `arcgis` added to dropdown; new Maps-page options (portal URL, API key, basemap, web map / scene / feature layer item IDs); OSM added to the basemap dropdown |
| `includes/class-geopress-maps.php` | `geopress_arcgis_options()`, `…_feature_layer_html()`, `…_webmap_embed()`, `…_webscene_embed()`, plus new `…_resolve_item_type()` (portal + transient cache) and `…_map_embed()` dispatcher; arcgis branches in `geopress_map()` / `geopress_post_map()` |
| `tests/Unit/Maps/ArcGISTest.php` | NEW — 13 tests (50 / 116 / 0 across the whole suite) |
| `tests/bootstrap.php` + `tests/wp-stubs.php` | Patchwork load-order fix + `get_transient`/`set_transient`/`DAY_IN_SECONDS` stubs |
| `tests/Unit/{…}` | `$wpdb->postmeta` / `$wpdb->posts` added in 5 test files |
| `README.md` / `CHANGES.TXT` / `CLAUDE.md` | ArcGIS provider, unified tag, options; 3.1 changelog |
| `geopress.php` + `tests/bootstrap.php` | `GEOPRESS_VERSION` 3.0 → 3.1 |

## Decisions taken (recorded in the planning step)

- **Scope:** bring the full feature set in one PR — point maps + web maps + 3D scenes + feature layers + the unified content tag.
- **Module loading:** single 5.0 CDN module entry + `$arcgis.import()`. No npm/bundler.
- **Basemap/key:** OSM default, optional Esri key.
- **Tag shape:** one `INSERT_ARCGIS_MAP(item_id)` rather than separate webmap/webscene tags; item type resolved from the portal so authors don't have to remember which kind of item they have.

## ⚠️ Known carry-overs (out of scope for this PR)
- Editor location-picker is still Mapstraction/OpenLayers regardless of provider. Switching it to `<arcgis-map>` with click-to-set is a follow-up.
- Declarative ArcGIS map *controls* (`<arcgis-zoom>` / `<arcgis-legend>` / `<arcgis-search>`) are partially used inside the embed helpers but not yet wired to the existing GeoPress controls options.

## Testing — needs manual smoke test before merge

- ✅ PHPUnit suite green (50 / 116 / 0).
- ✅ PHP syntax check passes for all changed files.
- ✅ `arcgis-map.js` parses as an ES module.
- ⚠️ **Live WP smoke test still needed**:
  1. Set provider to ArcGIS in GeoPress → Maps (defaults: OSM basemap, no key); verify a post map renders.
  2. Add a Location Platform API key, switch basemap to `arcgis/imagery`, confirm Esri imagery loads.
  3. Drop `INSERT_ARCGIS_MAP(<a-web-map-item-id>)` into a post → expect a 2D `<arcgis-map>` render.
  4. Drop `INSERT_ARCGIS_MAP(<a-web-scene-item-id>)` into a post → expect a 3D `<arcgis-scene>` render (same tag).

Opened as **DRAFT** until that smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
